### PR TITLE
Bump setup-node and checkout to v3 in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,9 +17,9 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'


### PR DESCRIPTION
## Summary
- Upgrade `actions/setup-node` from v2 to v3 to fix `Cache service responded with 400` failures in CI
- Upgrade `actions/checkout` from v2 to v3 for consistency with `coverage.yml`

Closes #6

## Test plan
- [ ] Verify the Unit Tests workflow runs successfully on this PR (no cache 400 error)
- [ ] Confirm matrix builds for Node 14.x and 16.x both pass