### PR TITLE
Grant Claude Code Review write access to PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,9 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
+      actions: read # Required for Claude to read CI results
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- Bump `pull-requests` from `read` to `write` so the Claude Code Review job can post comments on PRs.
- Add `actions: read` so Claude can inspect CI results during the review.

The job on PR #7 ran successfully (the SDK call returned in ~46s with no errors) but the post step logged `No buffered inline comments` and the run produced no PR comment — because read-only permissions left the action with no way to write back.

## Test plan
- [ ] After merging, open a follow-up PR and confirm the `claude-review` job posts a review comment.
