### PR TITLE
Add ULID variant for encoding and decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `variant` option on `encode()` and `decode()` for selecting the encoding
+  algorithm. The default `crockford` variant is unchanged. The new `ulid`
+  variant uses the ULID-compatible modulo-style algorithm, restoring the
+  encoding/decoding behaviour expected by ULID consumers that broke in 2.0.0.
+
+### Changed
+
+- `decode()`'s `asNumber: false` option is now optional, so passing only
+  `{ variant: 'ulid' }` type-checks without also specifying `asNumber`.
+
 ## [2.0.0]: 2023-07-24
 
 ### Fixed
@@ -43,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ability to encode a number to base 32
 - Ability to decode a base 32 string to a buffer
 
+[Unreleased]: https://github.com/devbanana/crockford-base32/compare/2.0.0...HEAD
 [2.0.0]: https://github.com/devbanana/crockford-base32/compare/1.1.0...2.0.0
 [1.1.0]: https://github.com/devbanana/crockford-base32/compare/1.0.1...1.1.0
 [1.0.1]: https://github.com/devbanana/crockford-base32/compare/1.0.0...1.0.1

--- a/README.md
+++ b/README.md
@@ -32,3 +32,59 @@ CrockfordBase32.decode('1J654', { asNumber: true }); // 822354n
 CrockfordBase32.encode(275_789_480_204_545_813_933_268_697_807_617_179_845n); // SXXHYC0JSN77K601AW3K31P0RM
 CrockfordBase32.decode('SXXHYC0JSN77K601AW3K31P0RM', { asNumber: true }); // 275789480204545813933268697807617179845n
 ```
+
+## Variants
+
+The default `crockford` variant follows Douglas Crockford's Base 32
+algorithm. It treats binary input as a bit stream, reading from left to right
+and padding remaining bits on the right.
+
+The `ulid` variant uses ULID-compatible modulo-style encoding and decoding. It
+treats the input as one integer, extracts base 32 digits with division and
+remainder, and pads on the left. The [ULID spec][ulid-spec] only fixes the
+alphabet; the modulo algorithm comes from the reference implementation's
+[`encodeTime`][ulid-encode] function. For background on the two valid Base 32
+interpretations ([RFC 4648][rfc-4648] vs. modulo), see [this
+discussion][ulid-discussion].
+
+[ulid-spec]: https://github.com/ulid/spec
+[ulid-encode]: https://github.com/ulid/javascript/blob/master/lib/index.ts
+[ulid-discussion]: https://github.com/ulid/spec/issues/73#issuecomment-1247445322
+[rfc-4648]: https://www.rfc-editor.org/rfc/rfc4648
+
+```javascript
+const { CrockfordBase32 } = require('crockford-base32');
+
+CrockfordBase32.encode(Buffer.from([0xff])); // ZW
+CrockfordBase32.encode(Buffer.from([0xff]), { variant: 'ulid' }); // 7Z
+
+CrockfordBase32.decode('01FZD39998855SS2YG4XP4T14P', {
+  variant: 'ulid',
+}).toString('hex'); // 017fda34a528414b9c8bd0276c4d0496
+
+CrockfordBase32.decode('7Z', {
+  variant: 'ulid',
+  asNumber: true,
+}); // 255n
+```
+
+The `ulid` variant only selects the ULID-compatible encoding algorithm. It does
+not validate that input is a valid ULID, require 16-byte buffers or
+26-character strings, generate ULIDs, validate timestamps, or enforce ULID
+overflow rules.
+
+Empty binary input and numeric zero both encode to the empty string, since
+neither has any bits to encode:
+
+```javascript
+CrockfordBase32.encode(Buffer.from([]), { variant: 'ulid' }); // ""
+CrockfordBase32.decode('', { variant: 'ulid' }).length; // 0
+CrockfordBase32.encode(0, { variant: 'ulid' }); // ""
+```
+
+### Migrating from 1.x
+
+Version 2.0.0 changed the encoding algorithm to read from the leftmost bit per
+the Crockford spec. If you were using this library to decode ULIDs and saw
+different output after upgrading, pass `{ variant: 'ulid' }` to restore the
+previous behaviour for ULID-encoded data.

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -4,7 +4,6 @@ import { Buffer } from 'buffer';
 describe('Base32Encoder', () => {
   describe('when encoding', () => {
     it('can encode a multiple of 5 bits', () => {
-      // noinspection SpellCheckingInspection
       expect(
         CrockfordBase32.encode(Buffer.from([0xa6, 0xe5, 0x63, 0x34, 0x5f])),
       ).toBe('MVJP6D2Z');
@@ -51,7 +50,6 @@ describe('Base32Encoder', () => {
     });
 
     it('can encode a UUID into base 32', () => {
-      // noinspection SpellCheckingInspection
       expect(
         CrockfordBase32.encode(
           Buffer.from('017cb3b93bcb40b6147d7813c5ad2339', 'hex'),
@@ -61,7 +59,6 @@ describe('Base32Encoder', () => {
 
     it("doesn't modify the input buffer", () => {
       const buffer = Buffer.from('test');
-      // noinspection SpellCheckingInspection
       expect(CrockfordBase32.encode(buffer)).toBe('EHJQ6X0');
       expect(buffer.toString()).toBe('test');
     });
@@ -112,17 +109,15 @@ describe('Base32Encoder', () => {
     });
 
     it('can encode a bigint', () => {
-      // Test encoding a bigint directly
       expect(CrockfordBase32.encode(255n, { variant: 'ulid' })).toBe('7Z');
     });
 
     it('can encode zero as a bigint', () => {
-      // Numeric zero has no bits to encode, so it produces an empty string
       expect(CrockfordBase32.encode(0n, { variant: 'ulid' })).toBe('');
     });
 
     it('can encode a real ULID', () => {
-      // The ULID from the original issue: 01FZD39998855SS2YG4XP4T14P
+      // The ULID from issue #4: 01FZD39998855SS2YG4XP4T14P
       expect(
         CrockfordBase32.encode(
           Buffer.from('017fda34a528414b9c8bd0276c4d0496', 'hex'),
@@ -193,7 +188,6 @@ describe('Base32Encoder', () => {
 
   describe('when decoding', () => {
     it('can decode a multiple of 5 bits', () => {
-      // noinspection SpellCheckingInspection
       expect(CrockfordBase32.decode('MVJP6D2Z').toString('hex')).toBe(
         'a6e563345f',
       );
@@ -233,7 +227,6 @@ describe('Base32Encoder', () => {
     );
 
     it('can decode a ULID', () => {
-      // noinspection SpellCheckingInspection
       expect(
         CrockfordBase32.decode('05YB7E9VSD0BC53XF09WBB9374').toString('hex'),
       ).toBe('017cb3b93bcb40b6147d7813c5ad2339');
@@ -254,14 +247,12 @@ describe('Base32Encoder', () => {
     });
 
     it('ignores hyphens', () => {
-      // noinspection SpellCheckingInspection
       expect(CrockfordBase32.decode('EDQPTS-90EDT7-4TBECW').toString()).toBe(
         'some string',
       );
     });
 
     it('ignores multiple adjacent hyphens', () => {
-      // noinspection SpellCheckingInspection
       expect(CrockfordBase32.decode('EDQPTS--90EDT7---4TBECW').toString()).toBe(
         'some string',
       );
@@ -277,7 +268,6 @@ describe('Base32Encoder', () => {
     });
 
     it('can decode zero', () => {
-      // Test decoding '0' returns Buffer with single zero byte
       const result = CrockfordBase32.decode('0', { variant: 'ulid' });
       expect(result.toString('hex')).toBe('00');
     });
@@ -289,7 +279,6 @@ describe('Base32Encoder', () => {
     });
 
     it('can decode as number', () => {
-      // Test decoding with asNumber option
       const result = CrockfordBase32.decode('7Z', {
         variant: 'ulid',
         asNumber: true,
@@ -306,14 +295,13 @@ describe('Base32Encoder', () => {
     });
 
     it('rejects invalid base 32 character', () => {
-      // Test error handling for invalid characters
       expect(() => {
         CrockfordBase32.decode('Z$Z', { variant: 'ulid' });
       }).toThrow('Invalid base 32 character found in string: $');
     });
 
     it('can decode a real ULID', () => {
-      // The ULID from the original issue: 01FZD39998855SS2YG4XP4T14P
+      // The ULID from issue #4: 01FZD39998855SS2YG4XP4T14P
       expect(
         CrockfordBase32.decode('01FZD39998855SS2YG4XP4T14P', {
           variant: 'ulid',
@@ -322,31 +310,24 @@ describe('Base32Encoder', () => {
     });
 
     it('translates I to 1', () => {
-      // Test error correction with I -> 1
-      // '7I' should decode same as '71'
       expect(
         CrockfordBase32.decode('7I', { variant: 'ulid' }).toString('hex'),
       ).toBe('e1');
     });
 
     it('translates L to 1', () => {
-      // Test error correction with L -> 1
-      // '7L' should decode same as '71'
       expect(
         CrockfordBase32.decode('7L', { variant: 'ulid' }).toString('hex'),
       ).toBe('e1');
     });
 
     it('translates O to 0', () => {
-      // Test error correction with O -> 0
-      // '7O' should decode same as '70'
       expect(
         CrockfordBase32.decode('7O', { variant: 'ulid' }).toString('hex'),
       ).toBe('e0');
     });
 
     it('ignores hyphens', () => {
-      // Test hyphen handling in ULID format
       expect(
         CrockfordBase32.decode('01FZD399-98855SS2-YG4XP4T14P', {
           variant: 'ulid',
@@ -381,7 +362,6 @@ describe('Base32Encoder', () => {
 
   describe('when round-tripping ULIDs', () => {
     it('can round-trip with leading zeros', () => {
-      // Test that values with leading zeros survive round-trip
       const original = Buffer.from('007fda34a528414b9c8bd0276c4d0496', 'hex');
       const encoded = CrockfordBase32.encode(original, { variant: 'ulid' });
       const decoded = CrockfordBase32.decode(encoded, { variant: 'ulid' });
@@ -389,7 +369,6 @@ describe('Base32Encoder', () => {
     });
 
     it('can round-trip with many leading zeros', () => {
-      // Test extreme case with many leading zeros
       const original = Buffer.from('00000000000000001234567890abcdef', 'hex');
       const encoded = CrockfordBase32.encode(original, { variant: 'ulid' });
       const decoded = CrockfordBase32.decode(encoded, { variant: 'ulid' });
@@ -397,7 +376,6 @@ describe('Base32Encoder', () => {
     });
 
     it('can round-trip all-zero buffer', () => {
-      // All-zero 2-byte buffer
       const original = Buffer.from([0x00, 0x00]);
       const encoded = CrockfordBase32.encode(original, { variant: 'ulid' });
       const decoded = CrockfordBase32.decode(encoded, { variant: 'ulid' });
@@ -421,7 +399,6 @@ describe('Base32Encoder', () => {
     });
 
     it('can round-trip a number', () => {
-      // Test encoding and decoding a number back to bigint
       const original = 123_456_789n;
       const encoded = CrockfordBase32.encode(original, { variant: 'ulid' });
       const decoded = CrockfordBase32.decode(encoded, {
@@ -432,7 +409,6 @@ describe('Base32Encoder', () => {
     });
 
     it('can round-trip a bigint', () => {
-      // Test encoding and decoding a large bigint
       const original = 10_336_657_440_695_546_835_250_649_691n;
       const encoded = CrockfordBase32.encode(original, { variant: 'ulid' });
       const decoded = CrockfordBase32.decode(encoded, {
@@ -443,7 +419,6 @@ describe('Base32Encoder', () => {
     });
 
     it('can round-trip max value (all 0xFF)', () => {
-      // Test maximum 16-byte value survives round-trip
       const original = Buffer.from('ffffffffffffffffffffffffffffffff', 'hex');
       const encoded = CrockfordBase32.encode(original, { variant: 'ulid' });
       const decoded = CrockfordBase32.decode(encoded, { variant: 'ulid' });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -67,6 +67,130 @@ describe('Base32Encoder', () => {
     });
   });
 
+  describe('when encoding ULIDs', () => {
+    it('can encode', () => {
+      // Test that variant option is accepted and produces ULID-style output
+      // ULID uses modulo-based encoding (right-to-left, padding left)
+      // 0xFF = 255 in decimal
+      // Crockford: 11111|11100 -> ZW (pads right)
+      // ULID: 00111|11111 -> 7Z (pads left)
+      expect(
+        CrockfordBase32.encode(Buffer.from([0xff]), { variant: 'ulid' }),
+      ).toBe('7Z');
+    });
+
+    it('can encode zero', () => {
+      // 1-byte buffer: ceil(8/5) = 2 characters
+      expect(
+        CrockfordBase32.encode(Buffer.from([0x00]), { variant: 'ulid' }),
+      ).toBe('00');
+    });
+
+    it('can encode an empty buffer', () => {
+      expect(CrockfordBase32.encode(Buffer.from([]), { variant: 'ulid' })).toBe(
+        '',
+      );
+    });
+
+    it('can encode multiple zeros', () => {
+      // 3-byte all-zero buffer: ceil(24/5) = 5 characters
+      expect(
+        CrockfordBase32.encode(Buffer.from([0x00, 0x00, 0x00]), {
+          variant: 'ulid',
+        }),
+      ).toBe('00000');
+    });
+
+    it('can encode a number', () => {
+      // 255 should encode to '7Z' like Buffer.from([0xff])
+      expect(CrockfordBase32.encode(255, { variant: 'ulid' })).toBe('7Z');
+    });
+
+    it('can encode zero as a number', () => {
+      // Numeric zero has no bits to encode, so it produces an empty string
+      expect(CrockfordBase32.encode(0, { variant: 'ulid' })).toBe('');
+    });
+
+    it('can encode a bigint', () => {
+      // Test encoding a bigint directly
+      expect(CrockfordBase32.encode(255n, { variant: 'ulid' })).toBe('7Z');
+    });
+
+    it('can encode zero as a bigint', () => {
+      // Numeric zero has no bits to encode, so it produces an empty string
+      expect(CrockfordBase32.encode(0n, { variant: 'ulid' })).toBe('');
+    });
+
+    it('can encode a real ULID', () => {
+      // The ULID from the original issue: 01FZD39998855SS2YG4XP4T14P
+      expect(
+        CrockfordBase32.encode(
+          Buffer.from('017fda34a528414b9c8bd0276c4d0496', 'hex'),
+          { variant: 'ulid' },
+        ),
+      ).toBe('01FZD39998855SS2YG4XP4T14P');
+    });
+
+    it('pads encoding for values with leading zeros - 16 bytes', () => {
+      // 16-byte buffer starting with 0x00 should pad to 26 characters
+      const result = CrockfordBase32.encode(
+        Buffer.from('00ffffffffffffffffffffffffffffff', 'hex'),
+        { variant: 'ulid' },
+      );
+      expect(result.length).toBe(26);
+      expect(result[0]).toBe('0'); // Should have leading zero
+    });
+
+    it('pads encoding for values with multiple leading zeros - 16 bytes', () => {
+      // 16-byte buffer with multiple leading zeros
+      const result = CrockfordBase32.encode(
+        Buffer.from('00000000000000000000000000000001', 'hex'),
+        { variant: 'ulid' },
+      );
+      expect(result).toBe('00000000000000000000000001');
+      expect(result.length).toBe(26);
+    });
+
+    it('pads encoding correctly for smaller buffers - 8 bytes', () => {
+      // 8-byte buffer: ceil(64/5) = 13 characters
+      const result = CrockfordBase32.encode(
+        Buffer.from('00ffffffffffffff', 'hex'),
+        { variant: 'ulid' },
+      );
+      expect(result.length).toBe(13);
+      expect(result[0]).toBe('0'); // Should have leading zero
+    });
+
+    it('pads encoding correctly for smaller buffers - 10 bytes', () => {
+      // 10-byte buffer: ceil(80/5) = 16 characters
+      const result = CrockfordBase32.encode(
+        Buffer.from('00ffffffffffffffffff', 'hex'),
+        { variant: 'ulid' },
+      );
+      expect(result.length).toBe(16);
+      expect(result[0]).toBe('0'); // Should have leading zero
+    });
+
+    it('pads encoding for all-zero buffer', () => {
+      // 2-byte all-zero buffer: ceil(16/5) = 4 characters
+      const result = CrockfordBase32.encode(Buffer.from([0x00, 0x00]), {
+        variant: 'ulid',
+      });
+      expect(result).toBe('0000');
+      expect(result.length).toBe(4);
+    });
+
+    it('pads encoding for 16-byte all-zero buffer', () => {
+      // 16-byte all-zero buffer: ceil(128/5) = 26 characters
+      const result = CrockfordBase32.encode(
+        Buffer.from('00000000000000000000000000000000', 'hex'),
+        { variant: 'ulid' },
+      );
+      expect(result).toBe('00000000000000000000000000');
+      expect(result.length).toBe(26);
+    });
+  });
+
   describe('when decoding', () => {
     it('can decode a multiple of 5 bits', () => {
       // noinspection SpellCheckingInspection
@@ -141,6 +265,189 @@ describe('Base32Encoder', () => {
       expect(CrockfordBase32.decode('EDQPTS--90EDT7---4TBECW').toString()).toBe(
         'some string',
       );
+    });
+  });
+
+  describe('when decoding ULIDs', () => {
+    it('can decode', () => {
+      // Test round-trip: encoding should decode back correctly
+      // '7Z' should decode back to Buffer.from([0xff])
+      const result = CrockfordBase32.decode('7Z', { variant: 'ulid' });
+      expect(result.toString('hex')).toBe('ff');
+    });
+
+    it('can decode zero', () => {
+      // Test decoding '0' returns Buffer with single zero byte
+      const result = CrockfordBase32.decode('0', { variant: 'ulid' });
+      expect(result.toString('hex')).toBe('00');
+    });
+
+    it('can decode an empty string', () => {
+      const result = CrockfordBase32.decode('', { variant: 'ulid' });
+      expect(result.length).toBe(0);
+      expect(result.toString('hex')).toBe('');
+    });
+
+    it('can decode as number', () => {
+      // Test decoding with asNumber option
+      const result = CrockfordBase32.decode('7Z', {
+        variant: 'ulid',
+        asNumber: true,
+      });
+      expect(result).toBe(255n);
+    });
+
+    it('can decode an empty string as a number', () => {
+      const result = CrockfordBase32.decode('', {
+        variant: 'ulid',
+        asNumber: true,
+      });
+      expect(result).toBe(0n);
+    });
+
+    it('rejects invalid base 32 character', () => {
+      // Test error handling for invalid characters
+      expect(() => {
+        CrockfordBase32.decode('Z$Z', { variant: 'ulid' });
+      }).toThrow('Invalid base 32 character found in string: $');
+    });
+
+    it('can decode a real ULID', () => {
+      // The ULID from the original issue: 01FZD39998855SS2YG4XP4T14P
+      expect(
+        CrockfordBase32.decode('01FZD39998855SS2YG4XP4T14P', {
+          variant: 'ulid',
+        }).toString('hex'),
+      ).toBe('017fda34a528414b9c8bd0276c4d0496');
+    });
+
+    it('translates I to 1', () => {
+      // Test error correction with I -> 1
+      // '7I' should decode same as '71'
+      expect(
+        CrockfordBase32.decode('7I', { variant: 'ulid' }).toString('hex'),
+      ).toBe('e1');
+    });
+
+    it('translates L to 1', () => {
+      // Test error correction with L -> 1
+      // '7L' should decode same as '71'
+      expect(
+        CrockfordBase32.decode('7L', { variant: 'ulid' }).toString('hex'),
+      ).toBe('e1');
+    });
+
+    it('translates O to 0', () => {
+      // Test error correction with O -> 0
+      // '7O' should decode same as '70'
+      expect(
+        CrockfordBase32.decode('7O', { variant: 'ulid' }).toString('hex'),
+      ).toBe('e0');
+    });
+
+    it('ignores hyphens', () => {
+      // Test hyphen handling in ULID format
+      expect(
+        CrockfordBase32.decode('01FZD399-98855SS2-YG4XP4T14P', {
+          variant: 'ulid',
+        }).toString('hex'),
+      ).toBe('017fda34a528414b9c8bd0276c4d0496');
+    });
+
+    it('can decode all-zero string - 4 characters', () => {
+      // 4 zeros: floor(4*5/8) = floor(2.5) = 2 bytes
+      const result = CrockfordBase32.decode('0000', { variant: 'ulid' });
+      expect(result.toString('hex')).toBe('0000');
+    });
+
+    it('can decode all-zero string - 26 characters', () => {
+      // 26 zeros: floor(26*5/8) = floor(16.25) = 16 bytes
+      const result = CrockfordBase32.decode('00000000000000000000000000', {
+        variant: 'ulid',
+      });
+      expect(result.toString('hex')).toBe('00000000000000000000000000000000');
+    });
+
+    it('can decode max value (all 0xFF)', () => {
+      // Maximum 16-byte value: all FFs
+      const maxEncoded = CrockfordBase32.encode(
+        Buffer.from('ffffffffffffffffffffffffffffffff', 'hex'),
+        { variant: 'ulid' },
+      );
+      const decoded = CrockfordBase32.decode(maxEncoded, { variant: 'ulid' });
+      expect(decoded.toString('hex')).toBe('ffffffffffffffffffffffffffffffff');
+    });
+  });
+
+  describe('when round-tripping ULIDs', () => {
+    it('can round-trip with leading zeros', () => {
+      // Test that values with leading zeros survive round-trip
+      const original = Buffer.from('007fda34a528414b9c8bd0276c4d0496', 'hex');
+      const encoded = CrockfordBase32.encode(original, { variant: 'ulid' });
+      const decoded = CrockfordBase32.decode(encoded, { variant: 'ulid' });
+      expect(decoded.toString('hex')).toBe('007fda34a528414b9c8bd0276c4d0496');
+    });
+
+    it('can round-trip with many leading zeros', () => {
+      // Test extreme case with many leading zeros
+      const original = Buffer.from('00000000000000001234567890abcdef', 'hex');
+      const encoded = CrockfordBase32.encode(original, { variant: 'ulid' });
+      const decoded = CrockfordBase32.decode(encoded, { variant: 'ulid' });
+      expect(decoded.toString('hex')).toBe('00000000000000001234567890abcdef');
+    });
+
+    it('can round-trip all-zero buffer', () => {
+      // All-zero 2-byte buffer
+      const original = Buffer.from([0x00, 0x00]);
+      const encoded = CrockfordBase32.encode(original, { variant: 'ulid' });
+      const decoded = CrockfordBase32.decode(encoded, { variant: 'ulid' });
+      expect(decoded.toString('hex')).toBe('0000');
+    });
+
+    it('can round-trip an empty buffer', () => {
+      const original = Buffer.from([]);
+      const encoded = CrockfordBase32.encode(original, { variant: 'ulid' });
+      const decoded = CrockfordBase32.decode(encoded, { variant: 'ulid' });
+      expect(encoded).toBe('');
+      expect(decoded.length).toBe(0);
+    });
+
+    it('can round-trip 16-byte all-zero buffer', () => {
+      // All-zero 16-byte buffer (like a zeroed ULID)
+      const original = Buffer.from('00000000000000000000000000000000', 'hex');
+      const encoded = CrockfordBase32.encode(original, { variant: 'ulid' });
+      const decoded = CrockfordBase32.decode(encoded, { variant: 'ulid' });
+      expect(decoded.toString('hex')).toBe('00000000000000000000000000000000');
+    });
+
+    it('can round-trip a number', () => {
+      // Test encoding and decoding a number back to bigint
+      const original = 123_456_789n;
+      const encoded = CrockfordBase32.encode(original, { variant: 'ulid' });
+      const decoded = CrockfordBase32.decode(encoded, {
+        variant: 'ulid',
+        asNumber: true,
+      });
+      expect(decoded).toBe(original);
+    });
+
+    it('can round-trip a bigint', () => {
+      // Test encoding and decoding a large bigint
+      const original = 10_336_657_440_695_546_835_250_649_691n;
+      const encoded = CrockfordBase32.encode(original, { variant: 'ulid' });
+      const decoded = CrockfordBase32.decode(encoded, {
+        variant: 'ulid',
+        asNumber: true,
+      });
+      expect(decoded).toBe(original);
+    });
+
+    it('can round-trip max value (all 0xFF)', () => {
+      // Test maximum 16-byte value survives round-trip
+      const original = Buffer.from('ffffffffffffffffffffffffffffffff', 'hex');
+      const encoded = CrockfordBase32.encode(original, { variant: 'ulid' });
+      const decoded = CrockfordBase32.decode(encoded, { variant: 'ulid' });
+      expect(decoded.toString('hex')).toBe('ffffffffffffffffffffffffffffffff');
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,12 @@ import { Buffer } from 'buffer';
 // noinspection SpellCheckingInspection
 const characters = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
 
-type DecodeAsNumberOptions = { asNumber: true };
-type DecodeAsBufferOptions = { asNumber: false };
+type EncodeOptions = { variant?: 'crockford' | 'ulid' };
+type DecodeAsNumberOptions = { asNumber: true; variant?: 'crockford' | 'ulid' };
+type DecodeAsBufferOptions = {
+  asNumber?: false;
+  variant?: 'crockford' | 'ulid';
+};
 
 /**
  * An implementation of the Crockford Base32 algorithm.
@@ -12,12 +16,20 @@ type DecodeAsBufferOptions = { asNumber: false };
  * Spec: https://www.crockford.com/base32.html
  */
 export class CrockfordBase32 {
-  static encode(input: Buffer | number | bigint): string {
+  static encode(
+    input: Buffer | number | bigint,
+    options?: EncodeOptions,
+  ): string {
     if (input instanceof Buffer) {
-      // Copy the input buffer so it isn't modified when we call `reverse()`
       input = Buffer.from(input);
     } else {
       input = this.createBuffer(input);
+    }
+
+    const variant = options?.variant ?? 'crockford';
+
+    if (variant === 'ulid') {
+      return this.encodeUlid(input);
     }
 
     const output: number[] = [];
@@ -57,6 +69,12 @@ export class CrockfordBase32 {
       .replace(/[IL]/g, '1')
       .replace(/-+/g, '');
 
+    const variant = options?.variant ?? 'crockford';
+
+    if (variant === 'ulid') {
+      return this.decodeUlid(input, options);
+    }
+
     const output: number[] = [];
     let bitsRead = 0;
     let buffer = 0;
@@ -82,6 +100,92 @@ export class CrockfordBase32 {
 
     if (buffer > 0) {
       output.push(buffer);
+    }
+
+    if (options?.asNumber === true) {
+      return this.asNumber(output);
+    }
+
+    return this.asBuffer(output);
+  }
+
+  private static encodeUlid(input: Buffer): string {
+    // ULID variant uses modulo-based encoding (right-to-left, padding left)
+    // Convert buffer to bigint
+    let value = 0n;
+    for (const byte of input) {
+      value = (value << 8n) | BigInt(byte);
+    }
+
+    // Use repeated division by 32 to extract base32 digits
+    const output: string[] = [];
+    while (value > 0n) {
+      const remainder = Number(value % 32n);
+      output.unshift(characters.charAt(remainder));
+      value /= 32n;
+    }
+
+    // Keep empty binary input empty so Buffer round-trips do not become 0x00.
+    if (input.length === 0) {
+      return '';
+    }
+
+    // Pad to the expected length based on input size
+    // Each byte requires ceil(8/5) = 2 base32 characters on average
+    // For n bytes: ceil(n * 8 / 5) characters
+    const expectedLength = Math.ceil((input.length * 8) / 5);
+    return output.join('').padStart(expectedLength, '0');
+  }
+
+  private static decodeUlid(
+    input: string,
+    options?: DecodeAsNumberOptions | DecodeAsBufferOptions,
+  ): bigint | Buffer {
+    // Empty encoded data represents no bytes; asNumber has no empty numeric
+    // value, so return the same numeric zero used by other empty decodes.
+    if (input.length === 0) {
+      return options?.asNumber === true ? 0n : Buffer.from([]);
+    }
+
+    // ULID variant uses modulo-based decoding (reverse of encoding)
+    // Treat the base32 string as a number in base 32
+    let value = 0n;
+
+    for (const character of input) {
+      const digit = characters.indexOf(character);
+      if (digit === -1) {
+        throw new Error(
+          `Invalid base 32 character found in string: ${character}`,
+        );
+      }
+      value = value * 32n + BigInt(digit);
+    }
+
+    // Calculate expected output length based on input string length
+    // Each base32 character represents 5 bits, so n characters = n*5 bits
+    // We use floor because the encoder may have added padding characters
+    // to reach the expected length, creating extra bits we should ignore
+    const expectedBytes = Math.floor((input.length * 5) / 8);
+
+    // Convert bigint to byte array
+    const output: number[] = [];
+    let temp = value;
+    while (temp > 0n) {
+      output.unshift(Number(temp & 0xffn));
+      temp >>= 8n;
+    }
+
+    // For all-zero input the bigint loop emits no bytes, so seed one zero
+    // byte. The padding loop below then extends to expectedBytes when needed
+    // (e.g. "0000" -> two bytes); single-character "0" decodes to one byte
+    // even though expectedBytes is 0.
+    if (value === 0n) {
+      output.push(0);
+    }
+
+    // Pad with leading zeros to match expected length
+    while (output.length < expectedBytes) {
+      output.unshift(0);
     }
 
     if (options?.asNumber === true) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import { Buffer } from 'buffer';
 
-// noinspection SpellCheckingInspection
 const characters = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
 
 type EncodeOptions = { variant?: 'crockford' | 'ulid' };
@@ -110,6 +109,11 @@ export class CrockfordBase32 {
   }
 
   private static encodeUlid(input: Buffer): string {
+    // Keep empty binary input empty so Buffer round-trips do not become 0x00.
+    if (input.length === 0) {
+      return '';
+    }
+
     // ULID variant uses modulo-based encoding (right-to-left, padding left)
     // Convert buffer to bigint
     let value = 0n;
@@ -125,15 +129,11 @@ export class CrockfordBase32 {
       value /= 32n;
     }
 
-    // Keep empty binary input empty so Buffer round-trips do not become 0x00.
-    if (input.length === 0) {
-      return '';
-    }
-
     // Pad to the expected length based on input size
-    // Each byte requires ceil(8/5) = 2 base32 characters on average
-    // For n bytes: ceil(n * 8 / 5) characters
+    // Each base32 character encodes 5 bits, so n bytes = n*8 bits
+    // require ceil(n*8/5) characters
     const expectedLength = Math.ceil((input.length * 8) / 5);
+
     return output.join('').padStart(expectedLength, '0');
   }
 


### PR DESCRIPTION
## Summary

- Adds a `variant: 'ulid'` option to `CrockfordBase32.encode()` and `.decode()` that uses the modulo-style algorithm from the [ULID reference implementation](https://github.com/ulid/javascript/blob/master/lib/index.ts), restoring ULID-compatible behaviour that broke in 2.0.0 (issue #4). The default `crockford` variant is unchanged.
- Relaxes the `asNumber: false` decode option to optional so callers can pass just `{ variant: 'ulid' }` without also specifying `asNumber`.
- Documents the variants, empty/zero behaviour, and the 1.x to 2.x migration path in the README, plus an `[Unreleased]` entry in the CHANGELOG.

The README explains why the modulo algorithm is correct (the [ULID spec](https://github.com/ulid/spec) only fixes the alphabet) and links to the [reference `encodeTime`](https://github.com/ulid/javascript/blob/master/lib/index.ts), [RFC 4648](https://www.rfc-editor.org/rfc/rfc4648), and [the discussion](https://github.com/ulid/spec/issues/73#issuecomment-1247445322) that walks through the two valid Base 32 interpretations.

Closes #4.

## Test plan

- [x] `npm test` — all 65 tests pass (existing crockford tests + new ULID encode / decode / round-trip suites)
- [x] `npm run test:cov` — 100% statement / branch / function / line coverage on `src/index.ts`
- [x] `npx tsc --noEmit` — type-check clean; verifies the relaxed `asNumber` option type
- [x] Real-world ULID from the original bug report round-trips: `01FZD39998855SS2YG4XP4T14P` to `017fda34a528414b9c8bd0276c4d0496`
- [x] Default crockford behaviour unchanged (existing tests still pass)
