### PR TITLE
Add optional checksum support and verify method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `checksum` option on `encode()` and `decode()` for appending and
+  validating Crockford's optional check symbol. The check symbol is one
+  character (`value mod 37`) appended to the encoded string. Defaults to
+  `false`; passing `{ variant: 'ulid', checksum: true }` is rejected at
+  both the type level and runtime since ULID has no checksum concept.
+- `verify(input: string)` static method for non-throwing checksum
+  validation — returns `true`/`false` instead of throwing.
+- Exported `InvalidChecksumCharacterError` and `InvalidChecksumError`
+  classes for `instanceof` discrimination of `decode()` checksum failures.
+
 ## [2.1.0] - 2026-04-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # crockford-base32
 
-An implementation of Douglas Crockford's Base 32 encoding algorithm.
+An implementation of Douglas Crockford's [Base 32 encoding algorithm](https://www.crockford.com/base32.html).
 
 ## Installation
 
@@ -88,3 +88,70 @@ Version 2.0.0 changed the encoding algorithm to read from the leftmost bit per
 the Crockford spec. If you were using this library to decode ULIDs and saw
 different output after upgrading, pass `{ variant: 'ulid' }` to restore the
 previous behaviour for ULID-encoded data.
+
+## Checksums
+
+Crockford's [check symbol](https://www.crockford.com/base32.html) is an
+optional single character appended to an encoded string to detect
+transcription errors. It is computed as `value mod 37` — one of 37
+characters: the 32-symbol Base 32 alphabet plus `*`, `~`, `$`, `=`, and `U`
+for values 32–36.
+
+Opt in via `{ checksum: true }`:
+
+```javascript
+const { CrockfordBase32 } = require('crockford-base32');
+
+CrockfordBase32.encode(Buffer.from([0xff]), { checksum: true }); // ZW~
+CrockfordBase32.encode(255n, { checksum: true }); // ZW~
+
+CrockfordBase32.decode('ZW~', { checksum: true }).toString('hex'); // ff
+CrockfordBase32.decode('ZW~', { checksum: true, asNumber: true }); // 255n
+```
+
+The same hyphen, case, and `I`/`L`/`O` normalization that applies to
+unchecksummed input also applies to checksummed input, including the
+trailing check symbol:
+
+```javascript
+CrockfordBase32.decode('ehjq6x-0v', { checksum: true }).toString(); // test
+
+// L and O at the check position are auto-corrected to 1 and 0
+CrockfordBase32.decode('1c8pal', { checksum: true, asNumber: true }); // 725349n
+CrockfordBase32.decode('1fa84o', { checksum: true, asNumber: true }); // 775298n
+```
+
+When validation fails, `decode()` throws one of two exported error classes:
+
+```javascript
+const {
+  CrockfordBase32,
+  InvalidChecksumCharacterError,
+  InvalidChecksumError,
+} = require('crockford-base32');
+
+try {
+  CrockfordBase32.decode('ZW!', { checksum: true });
+} catch (err) {
+  err instanceof InvalidChecksumCharacterError; // true — '!' is not a valid check character
+}
+
+try {
+  CrockfordBase32.decode('ZW0', { checksum: true });
+} catch (err) {
+  err instanceof InvalidChecksumError; // true — '0' is valid but does not match
+}
+```
+
+For a yes/no check without try/catch, use `verify()`:
+
+```javascript
+CrockfordBase32.verify('ZW~'); // true
+CrockfordBase32.verify('ZW0'); // false (mismatched checksum)
+CrockfordBase32.verify('ZW!'); // false (invalid check character)
+CrockfordBase32.verify(''); // false (empty input)
+```
+
+Checksums apply only to the default `crockford` variant. Passing
+`{ variant: 'ulid', checksum: true }` is rejected at both the type level
+and runtime — ULID's canonical form has no check symbol concept.

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -64,6 +64,93 @@ describe('Base32Encoder', () => {
     });
   });
 
+  describe('when encoding with a checksum', () => {
+    it('appends a single check symbol', () => {
+      // 0xff = 255, encoded as 'ZW'; 255 % 37 = 33 -> '~'
+      expect(
+        CrockfordBase32.encode(Buffer.from([0xff]), { checksum: true }),
+      ).toBe('ZW~');
+    });
+
+    it('computes the checksum from the numeric value, not the encoded chars', () => {
+      // 0xa6e563345f as a bigint mod 37 = 27, characters[27] = 'V'
+      expect(
+        CrockfordBase32.encode(Buffer.from([0xa6, 0xe5, 0x63, 0x34, 0x5f]), {
+          checksum: true,
+        }),
+      ).toBe('MVJP6D2ZV');
+    });
+
+    it('can encode a number with checksum', () => {
+      // 1 % 37 = 1 -> '1'; encode(1) is '04'
+      expect(CrockfordBase32.encode(1, { checksum: true })).toBe('041');
+    });
+
+    it('can encode a bigint with checksum', () => {
+      // 255n % 37 = 33 -> '~'; encode(255n) is 'ZW'
+      expect(CrockfordBase32.encode(255n, { checksum: true })).toBe('ZW~');
+    });
+
+    it('produces a "0" check symbol when input is the number zero', () => {
+      // encode(0) is ''; 0 % 37 = 0 -> '0'
+      expect(CrockfordBase32.encode(0, { checksum: true })).toBe('0');
+    });
+
+    it('produces a "0" check symbol for an empty buffer', () => {
+      expect(CrockfordBase32.encode(Buffer.from([]), { checksum: true })).toBe(
+        '0',
+      );
+    });
+
+    it.each`
+      byte    | char
+      ${0x20} | ${'*'}
+      ${0x21} | ${'~'}
+      ${0x22} | ${'$'}
+      ${0x23} | ${'='}
+      ${0x24} | ${'U'}
+    `(
+      'can produce extended check character $char',
+      ({ byte, char }: { byte: number; char: string }) => {
+        const result = CrockfordBase32.encode(Buffer.from([byte]), {
+          checksum: true,
+        });
+        expect(result.charAt(result.length - 1)).toBe(char);
+      },
+    );
+
+    it('does not append a checksum when checksum option is false', () => {
+      expect(
+        CrockfordBase32.encode(Buffer.from([0xff]), { checksum: false }),
+      ).toBe('ZW');
+    });
+
+    it('does not append a checksum when checksum option is omitted', () => {
+      expect(
+        CrockfordBase32.encode(Buffer.from([0xff]), { variant: 'crockford' }),
+      ).toBe('ZW');
+    });
+
+    it("doesn't modify the input buffer", () => {
+      // 'test' = 0x74 0x65 0x73 0x74; folded mod 37 = 27 -> 'V'
+      const buffer = Buffer.from('test');
+      expect(CrockfordBase32.encode(buffer, { checksum: true })).toBe(
+        'EHJQ6X0V',
+      );
+      expect(buffer.toString()).toBe('test');
+    });
+
+    it('rejects checksum: true with the ulid variant at runtime', () => {
+      expect(() =>
+        CrockfordBase32.encode(Buffer.from([0xff]), {
+          variant: 'ulid',
+          // @ts-expect-error - the type system should reject this combination
+          checksum: true,
+        }),
+      ).toThrowError('Checksums are not supported with the ulid variant');
+    });
+  });
+
   describe('when encoding ULIDs', () => {
     it('can encode', () => {
       // Test that variant option is accepted and produces ULID-style output

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,4 +1,8 @@
-import { CrockfordBase32 } from './index';
+import {
+  CrockfordBase32,
+  InvalidChecksumCharacterError,
+  InvalidChecksumError,
+} from './index';
 import { Buffer } from 'buffer';
 
 describe('Base32Encoder', () => {
@@ -362,6 +366,164 @@ describe('Base32Encoder', () => {
       expect(CrockfordBase32.decode('EDQPTS--90EDT7---4TBECW').toString()).toBe(
         'some string',
       );
+    });
+  });
+
+  describe('when decoding with a checksum', () => {
+    it('round-trips a single byte', () => {
+      // 0xff encodes to 'ZW~' with checksum
+      expect(
+        CrockfordBase32.decode('ZW~', { checksum: true }).toString('hex'),
+      ).toBe('ff');
+    });
+
+    it('decodes a multi-byte value with checksum', () => {
+      expect(
+        CrockfordBase32.decode('MVJP6D2ZV', { checksum: true }).toString('hex'),
+      ).toBe('a6e563345f');
+    });
+
+    it('decodes a value with leading zeros', () => {
+      // Buffer.from([0, 0, 0xa9]) -> '000AJ', checksum = 0xa9 % 37 = 21 -> 'N'
+      expect(
+        CrockfordBase32.decode('000AJN', { checksum: true }).toString('hex'),
+      ).toBe('0000a9');
+    });
+
+    it('decodes "test" with checksum', () => {
+      expect(
+        CrockfordBase32.decode('EHJQ6X0V', { checksum: true }).toString(),
+      ).toBe('test');
+    });
+
+    it('returns a number when asNumber is true', () => {
+      expect(
+        CrockfordBase32.decode('ZW~', { checksum: true, asNumber: true }),
+      ).toBe(255n);
+    });
+
+    it('decodes "0" (empty data + zero checksum) to an empty buffer', () => {
+      const result = CrockfordBase32.decode('0', { checksum: true });
+      expect(result.length).toBe(0);
+    });
+
+    it('decodes "0" as 0n when asNumber is true', () => {
+      expect(
+        CrockfordBase32.decode('0', { checksum: true, asNumber: true }),
+      ).toBe(0n);
+    });
+
+    it('strips hyphens before validating the checksum', () => {
+      expect(
+        CrockfordBase32.decode('EHJQ6X-0V', { checksum: true }).toString(),
+      ).toBe('test');
+    });
+
+    it('accepts a lowercase check symbol', () => {
+      // 0x24 encodes to '4GU'; lowercase 'u' should normalize to 'U'
+      expect(
+        CrockfordBase32.decode('4Gu', { checksum: true }).toString('hex'),
+      ).toBe('24');
+    });
+
+    it.each`
+      byte    | char
+      ${0x20} | ${'*'}
+      ${0x21} | ${'~'}
+      ${0x22} | ${'$'}
+      ${0x23} | ${'='}
+      ${0x24} | ${'U'}
+    `(
+      'accepts extended check character $char',
+      ({ byte, char }: { byte: number; char: string }) => {
+        const encoded = CrockfordBase32.encode(Buffer.from([byte]), {
+          checksum: true,
+        });
+        expect(encoded.endsWith(char)).toBe(true);
+        const decoded = CrockfordBase32.decode(encoded, { checksum: true });
+        expect(decoded.toString('hex')).toBe(
+          byte.toString(16).padStart(2, '0'),
+        );
+      },
+    );
+
+    it('still applies I/L/O substitution to the data portion', () => {
+      // 'AIm0' decodes to bytes [0x50, 0x68]; their checksum folds to 'C'
+      expect(
+        CrockfordBase32.decode('AIm0C', { checksum: true }).toString('hex'),
+      ).toBe('5068');
+    });
+
+    it('throws InvalidChecksumCharacterError on empty input', () => {
+      expect(() => CrockfordBase32.decode('', { checksum: true })).toThrow(
+        InvalidChecksumCharacterError,
+      );
+    });
+
+    it('throws InvalidChecksumCharacterError on invalid trailing character', () => {
+      expect(() => CrockfordBase32.decode('ZW!', { checksum: true })).toThrow(
+        InvalidChecksumCharacterError,
+      );
+    });
+
+    it('auto-corrects I to 1 in the check symbol position', () => {
+      // Buffer.from([1]) encodes to '04' with checksum '1'; typing 'I' for
+      // '1' at the end should still validate after I->1 normalization.
+      expect(
+        CrockfordBase32.decode('04I', { checksum: true }).toString('hex'),
+      ).toBe('01');
+    });
+
+    it('auto-corrects L to 1 in the check symbol position', () => {
+      expect(
+        CrockfordBase32.decode('04L', { checksum: true }).toString('hex'),
+      ).toBe('01');
+    });
+
+    it('auto-corrects O to 0 in the check symbol position', () => {
+      // Empty buffer encodes to '0' with checksum '0'; typing 'O' for '0'
+      // at the end should still validate after O->0 normalization.
+      expect(CrockfordBase32.decode('O', { checksum: true }).length).toBe(0);
+    });
+
+    it('throws InvalidChecksumError on a mismatched checksum', () => {
+      // 0xff's correct checksum is '~'; '0' is wrong
+      expect(() => CrockfordBase32.decode('ZW0', { checksum: true })).toThrow(
+        InvalidChecksumError,
+      );
+    });
+
+    it('rejects U in the data portion when checksum is enabled', () => {
+      // The check symbol is the LAST char only; an earlier U is still invalid
+      expect(() => CrockfordBase32.decode('UA0', { checksum: true })).toThrow(
+        'Invalid base 32 character found in string: U',
+      );
+    });
+
+    it('does not validate a checksum when option is omitted', () => {
+      // Without checksum: true, '~' is just an invalid base32 character
+      expect(() => CrockfordBase32.decode('ZW~')).toThrow(
+        'Invalid base 32 character',
+      );
+    });
+
+    it('rejects checksum: true with the ulid variant at runtime', () => {
+      expect(() =>
+        // @ts-expect-error - the type system should reject this combination
+        CrockfordBase32.decode('ZW~', {
+          variant: 'ulid',
+          checksum: true,
+        }),
+      ).toThrowError('Checksums are not supported with the ulid variant');
+    });
+
+    it('exports error classes that extend Error and have proper names', () => {
+      const charErr = new InvalidChecksumCharacterError('msg');
+      const sumErr = new InvalidChecksumError('msg');
+      expect(charErr).toBeInstanceOf(Error);
+      expect(sumErr).toBeInstanceOf(Error);
+      expect(charErr.name).toBe('InvalidChecksumCharacterError');
+      expect(sumErr.name).toBe('InvalidChecksumError');
     });
   });
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -527,6 +527,78 @@ describe('Base32Encoder', () => {
     });
   });
 
+  describe('when verifying', () => {
+    it('returns true for a valid checksummed string', () => {
+      expect(CrockfordBase32.verify('ZW~')).toBe(true);
+    });
+
+    it('returns true for a multi-byte checksummed string', () => {
+      expect(CrockfordBase32.verify('MVJP6D2ZV')).toBe(true);
+    });
+
+    it('returns true for a checksummed string with hyphens', () => {
+      expect(CrockfordBase32.verify('EHJQ6X-0V')).toBe(true);
+    });
+
+    it('returns true for lowercase input', () => {
+      expect(CrockfordBase32.verify('mvjp6d2zv')).toBe(true);
+    });
+
+    it.each`
+      input    | description
+      ${'04I'} | ${'I in check position'}
+      ${'04L'} | ${'L in check position'}
+      ${'O'}   | ${'O in check position'}
+    `(
+      'returns true with auto-corrected $description',
+      ({ input }: { input: string }) => {
+        expect(CrockfordBase32.verify(input)).toBe(true);
+      },
+    );
+
+    it('returns true for "0" (empty data with zero checksum)', () => {
+      expect(CrockfordBase32.verify('0')).toBe(true);
+    });
+
+    it('returns true for an encode round-trip', () => {
+      const encoded = CrockfordBase32.encode(Buffer.from('test'), {
+        checksum: true,
+      });
+      expect(CrockfordBase32.verify(encoded)).toBe(true);
+    });
+
+    it('returns false for empty input', () => {
+      expect(CrockfordBase32.verify('')).toBe(false);
+    });
+
+    it('returns false for an invalid check character', () => {
+      expect(CrockfordBase32.verify('ZW!')).toBe(false);
+    });
+
+    it('returns false for a mismatched checksum', () => {
+      // 0xff's correct checksum is '~'; '0' is wrong
+      expect(CrockfordBase32.verify('ZW0')).toBe(false);
+    });
+
+    it('returns false for an invalid base32 character in the data portion', () => {
+      // U is not allowed in the data; 'X' at the end is a valid check char
+      expect(CrockfordBase32.verify('UAX')).toBe(false);
+    });
+
+    it('returns false for a "U" check symbol that does not match', () => {
+      // 'U' = 36; for empty data, checksum is 0, so 'U' alone is a mismatch
+      expect(CrockfordBase32.verify('U')).toBe(false);
+    });
+
+    it('does not throw for non-string input', () => {
+      // verify is a yes/no contract — even programmer-error calls return false
+      expect(() =>
+        CrockfordBase32.verify(null as unknown as string),
+      ).not.toThrow();
+      expect(CrockfordBase32.verify(null as unknown as string)).toBe(false);
+    });
+  });
+
   describe('when decoding ULIDs', () => {
     it('can decode', () => {
       // Test round-trip: encoding should decode back correctly

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,6 +181,22 @@ export class CrockfordBase32 {
     return this.asBuffer(output);
   }
 
+  /**
+   * Validates whether `input` is a Crockford Base32 string with a correct
+   * trailing check symbol. Returns false for any malformed input (invalid
+   * characters, mismatched checksum, empty string), never throws.
+   *
+   * Use {@link decode} with `{ checksum: true }` if you need typed errors.
+   */
+  static verify(input: string): boolean {
+    try {
+      this.decode(input, { checksum: true });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   private static encodeUlid(input: Buffer): string {
     // Keep empty binary input empty so Buffer round-trips do not become 0x00.
     if (input.length === 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,9 @@ export class InvalidChecksumCharacterError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'InvalidChecksumCharacterError';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
   }
 }
 
@@ -22,6 +25,9 @@ export class InvalidChecksumError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'InvalidChecksumError';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,14 +3,27 @@ import { Buffer } from 'buffer';
 const characters = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
 const checksumCharacters = '*~$=U';
 
-type EncodeOptions =
+type VariantWithChecksum =
   | { variant?: 'crockford'; checksum?: boolean }
   | { variant: 'ulid'; checksum?: never };
-type DecodeAsNumberOptions = { asNumber: true; variant?: 'crockford' | 'ulid' };
-type DecodeAsBufferOptions = {
-  asNumber?: false;
-  variant?: 'crockford' | 'ulid';
-};
+
+type EncodeOptions = VariantWithChecksum;
+type DecodeAsNumberOptions = { asNumber: true } & VariantWithChecksum;
+type DecodeAsBufferOptions = { asNumber?: false } & VariantWithChecksum;
+
+export class InvalidChecksumCharacterError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidChecksumCharacterError';
+  }
+}
+
+export class InvalidChecksumError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidChecksumError';
+  }
+}
 
 /**
  * An implementation of the Crockford Base32 algorithm.
@@ -66,12 +79,12 @@ export class CrockfordBase32 {
     return result;
   }
 
-  private static computeChecksum(input: Buffer): string {
+  private static computeChecksum(bytes: Iterable<number>): string {
     // Crockford's check symbol is value mod 37, where value is the number the
     // symbols represent. Fold byte-by-byte to avoid materializing a bigint;
     // acc stays < 37 so (acc * 256 + byte) fits comfortably in a JS number.
     let acc = 0;
-    for (const byte of input) {
+    for (const byte of bytes) {
       acc = (acc * 256 + byte) % 37;
     }
 
@@ -94,9 +107,32 @@ export class CrockfordBase32 {
       .replace(/-+/g, '');
 
     const variant = options?.variant ?? 'crockford';
+    const checksum = options?.checksum ?? false;
 
     if (variant === 'ulid') {
+      if (checksum) {
+        throw new Error('Checksums are not supported with the ulid variant');
+      }
       return this.decodeUlid(input, options);
+    }
+
+    let providedCheck: string | null = null;
+    if (checksum) {
+      if (input.length === 0) {
+        throw new InvalidChecksumCharacterError(
+          'Cannot validate checksum: input is empty',
+        );
+      }
+
+      const last = input.charAt(input.length - 1);
+      if ((characters + checksumCharacters).indexOf(last) === -1) {
+        throw new InvalidChecksumCharacterError(
+          `Invalid checksum character: ${last}`,
+        );
+      }
+
+      providedCheck = last;
+      input = input.slice(0, -1);
     }
 
     const output: number[] = [];
@@ -127,6 +163,15 @@ export class CrockfordBase32 {
     // be canonical zero padding.
     if (buffer > 0 || bitsRead >= 5) {
       output.push(buffer);
+    }
+
+    if (providedCheck !== null) {
+      const computedCheck = this.computeChecksum(output);
+      if (providedCheck !== computedCheck) {
+        throw new InvalidChecksumError(
+          `Checksum mismatch: expected '${computedCheck}' but found '${providedCheck}'`,
+        );
+      }
     }
 
     if (options?.asNumber === true) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,11 @@
 import { Buffer } from 'buffer';
 
 const characters = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+const checksumCharacters = '*~$=U';
 
-type EncodeOptions = { variant?: 'crockford' | 'ulid' };
+type EncodeOptions =
+  | { variant?: 'crockford'; checksum?: boolean }
+  | { variant: 'ulid'; checksum?: never };
 type DecodeAsNumberOptions = { asNumber: true; variant?: 'crockford' | 'ulid' };
 type DecodeAsBufferOptions = {
   asNumber?: false;
@@ -26,8 +29,12 @@ export class CrockfordBase32 {
     }
 
     const variant = options?.variant ?? 'crockford';
+    const checksum = options?.checksum ?? false;
 
     if (variant === 'ulid') {
+      if (checksum) {
+        throw new Error('Checksums are not supported with the ulid variant');
+      }
       return this.encodeUlid(input);
     }
 
@@ -50,7 +57,25 @@ export class CrockfordBase32 {
       output.push((buffer << (5 - bitsRead)) & 0x1f);
     }
 
-    return output.map(byte => characters.charAt(byte)).join('');
+    let result = output.map(byte => characters.charAt(byte)).join('');
+
+    if (checksum) {
+      result += this.computeChecksum(input);
+    }
+
+    return result;
+  }
+
+  private static computeChecksum(input: Buffer): string {
+    // Crockford's check symbol is value mod 37, where value is the number the
+    // symbols represent. Fold byte-by-byte to avoid materializing a bigint;
+    // acc stays < 37 so (acc * 256 + byte) fits comfortably in a JS number.
+    let acc = 0;
+    for (const byte of input) {
+      acc = (acc * 256 + byte) % 37;
+    }
+
+    return (characters + checksumCharacters).charAt(acc);
   }
 
   static decode(input: string, options: DecodeAsNumberOptions): bigint;


### PR DESCRIPTION
## Summary
- Adds Crockford's optional check symbol (`value mod 37`) to `encode()` and `decode()` via `{ checksum: true }`. Default off, fully backward compatible.
- Adds `verify(input: string)` for non-throwing yes/no validation — delegates to `decode({ checksum: true })` under a try/catch.
- Exports `InvalidChecksumCharacterError` (trailing symbol isn't a valid check character) and `InvalidChecksumError` (valid symbol, doesn't match computed value) for `instanceof` discrimination.
- Discriminated-union types (`{ variant: 'crockford'; checksum?: boolean } | { variant: 'ulid'; checksum?: never }`) reject `{ variant: 'ulid', checksum: true }` at the type level, with a runtime guard for JS callers that bypass the types.
- Existing `I`/`L`/`O` auto-correction applies uniformly across the input, including the trailing check symbol — the check alphabet (`*`, `~`, `$`, `=`, `U`) doesn't contain I/L/O, so substitution can never collide.
- README has a new Checksums section with usage examples (encode/decode/verify, error classes, I/L/O at the check position); CHANGELOG entries under `[Unreleased]`.

Closes #12

## Test plan
- [x] `npm test` — 124/124 passing (40 new tests across encode, decode, and verify)
- [x] `npm run test:cov` — 100% statements/branches/functions/lines maintained
- [x] `npm run lint` — clean
- [x] README examples verified end-to-end via `node -e` against the built library (`ehjq6x-0v` → `test`, `1c8pal` → `725349n`, `1fa84o` → `775298n`)
