### PR TITLE
Reject unsafe integer inputs in encode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Exported `InvalidChecksumCharacterError` and `InvalidChecksumError`
   classes for `instanceof` discrimination of `decode()` checksum failures.
 
+### Fixed
+
+- `encode()` now rejects unsafe `number` inputs (above
+  `Number.MAX_SAFE_INTEGER`, fractional, `NaN`, or `Infinity`) with a
+  clear error instead of silently encoding a float-rounded value. Pass a
+  `bigint` for values larger than `Number.MAX_SAFE_INTEGER`.
+
 ## [2.1.0] - 2026-04-25
 
 ### Added

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -47,6 +47,12 @@ describe('Base32Encoder', () => {
       );
     });
 
+    it('rejects unsafe number inputs', () => {
+      expect(() =>
+        CrockfordBase32.encode(Number.MAX_SAFE_INTEGER + 1),
+      ).toThrowError('Input must be a safe integer');
+    });
+
     it('cannot take a negative bigint', () => {
       expect(() => CrockfordBase32.encode(-21233n)).toThrowError(
         'Input cannot be a negative number',

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -47,10 +47,17 @@ describe('Base32Encoder', () => {
       );
     });
 
-    it('rejects unsafe number inputs', () => {
-      expect(() =>
-        CrockfordBase32.encode(Number.MAX_SAFE_INTEGER + 1),
-      ).toThrowError('Input must be a safe integer');
+    it.each`
+      label                       | input
+      ${'above MAX_SAFE_INTEGER'} | ${Number.MAX_SAFE_INTEGER + 1}
+      ${'fractional'}             | ${3.14}
+      ${'NaN'}                    | ${Number.NaN}
+      ${'Infinity'}               | ${Number.POSITIVE_INFINITY}
+      ${'-Infinity'}              | ${Number.NEGATIVE_INFINITY}
+    `('rejects $label number inputs', ({ input }: { input: number }) => {
+      expect(() => CrockfordBase32.encode(input)).toThrowError(
+        'Input must be a safe integer',
+      );
     });
 
     it('cannot take a negative bigint', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -292,6 +292,10 @@ export class CrockfordBase32 {
 
   private static createBuffer(input: number | bigint): Buffer {
     if (typeof input === 'number') {
+      if (!Number.isSafeInteger(input)) {
+        throw new Error('Input must be a safe integer');
+      }
+
       input = BigInt(input);
     }
 


### PR DESCRIPTION
## Summary

- `encode()` previously accepted any `number`, but values above `Number.MAX_SAFE_INTEGER` were silently coerced through a lossy float by `BigInt()`, encoding a different value than the caller passed in (e.g. `9007199254740993` became `9007199254740992n`).
- Guard `createBuffer` with `Number.isSafeInteger`, throwing `Input must be a safe integer` for unsafe, fractional, `NaN`, or `Infinity` inputs. `bigint` callers are unaffected — pass a `bigint` for values larger than `Number.MAX_SAFE_INTEGER`.
- CHANGELOG updated under Unreleased › Fixed.

## Test plan

- [x] `npm test` — all 125 tests pass, including the new `rejects unsafe number inputs` case